### PR TITLE
1.0.1 Bug Fixes by Alan Hench

### DIFF
--- a/generate.js
+++ b/generate.js
@@ -860,6 +860,7 @@ function readUserInput()
 	if(thereIsAnError)
 		return false;
 	myWorld.processData = false;
+	myWorld.dataObj = myWorld.saveDataObj();
 	return myWorld;
 }
 

--- a/planet_building_world_class.js
+++ b/planet_building_world_class.js
@@ -857,6 +857,7 @@ function world()
 				if(extrFnc())
 					ROTATIONAL_PERIOD *= extrFnc();
 			}
+			if(me.dataObj.remarks.indexOf('Pl') < 0)    // if Pl code given, would also give Tz code if needed, so skip the check
 			me.lockCheck();
 		}
 		ROTATIONAL_PERIOD = Math.floor(ROTATIONAL_PERIOD*100)/100;

--- a/planet_building_world_class.js
+++ b/planet_building_world_class.js
@@ -2532,7 +2532,8 @@ function nil(worldObject)
 			s += "Corporate ";
 		if(me.world.gov == 6)
 			s += "Colonial ";
-		s += me.type.name;
+		if(me.type)
+                        s += me.type.name;
 		return s;
 	}
 

--- a/planet_building_world_class.js
+++ b/planet_building_world_class.js
@@ -2445,7 +2445,8 @@ function tcs(world)
 
 	me.generate = function()
 	{
-		me.classes = [];
+//		me.classes = [];
+            if(me.classes.length == 0)
 		for(var i=0;i<ALL_TC.length;i++)
 			if(ALL_TC[i].rules(me.world))
 				me.add(ALL_TC[i].code);
@@ -3540,6 +3541,8 @@ function fullSystem(mainWorldObj, sysDiv, symbolDiv, detailsDiv, generate_now)
 			me.mainWorld.isSatellite = false;
 		if(mwType == "Lk")
 			me.mainWorld.tcs.add("Lk");
+//                if(me.mainWorld.dataObj.remarks.indexOf("Tz") >= 0)
+//                        me.mainWorld.tcs.add("Tz");
 		var mainWorldPlaced = false;
 		if(!uPObj.prefs.main_world_hz_only)
 		{

--- a/planet_building_world_class.js
+++ b/planet_building_world_class.js
@@ -3524,6 +3524,15 @@ function fullSystem(mainWorldObj, sysDiv, symbolDiv, detailsDiv, generate_now)
 									me.totalAvailOrb += orbit_set.availableOrbitCount();
 								});
 		var mwType = "";
+                if(me.mainWorld.dataObj.remarks.indexOf("Pl") >= 0)
+                {
+                    mwType = "";
+                    me.mainWorld.tcs.del("Pl");
+                }
+                else if(me.mainWorld.dataObj.remarks.indexOf("Lk") >= 0 || me.mainWorld.dataObj.remarks.indexOf("Sa") >= 0)
+                        mwType = "Sa";
+                else
+                {
 		if(!uPObj.prefs.main_world_is_sat && !uPObj.prefs.main_world_not_sat && me.mainWorld.uwp.size != 0)
 		{
 			mwSatTbl = new dice_table(MAIN_WORLD_SATELLITE_TABLE);
@@ -3533,6 +3542,7 @@ function fullSystem(mainWorldObj, sysDiv, symbolDiv, detailsDiv, generate_now)
 			mwType = dice(1) > 3 ? "Sa" : "Lk";
 		if(uPObj.prefs.main_world_not_sat || me.mainWorld.uwp.size == 0)
 			mwType = "";
+                }
 		if(mwType == "Sa" || mwType == "Lk")
 		{
 			me.mainWorld.tcs.add("Sa");

--- a/world_mapping.js
+++ b/world_mapping.js
@@ -2763,13 +2763,13 @@ function worldHex(worldMapObj, parentObj, parentTriangle, left_offset, top_offse
 	{
 		var neighbours = [];
 		var wsize = me.map.world.uwp.size;
-		if(me.x == -1 && me.y == -1) //NORTH POLE
+		if(me.hexID == -1 || (me.x == -1 && me.y == -1)) //NORTH POLE
 		{
 			for(var i=0;i<me.map.rows[0].length;i++)
 				neighbours.push(me.map.rows[0][i]);
 			return neighbours;
 		}	
-		if(me.x == -2 && me.y == -2) //SOUTH POLE
+		if(me.hexID == -2 || (me.x == -2 && me.y == -2)) //SOUTH POLE
 		{
 			for(var i=0;i<me.map.rows[3*wsize-2].length;i++)
 				neighbours.push(me.map.rows[3*wsize-2][i]);
@@ -3177,7 +3177,7 @@ function generateHexMap(parentHex, mapType, mapClass)
 
 
 	var userSeed = parseInt(document.getElementById("seed").value);
-	var seedUsed = userSeed + parentHex.columnNumber * 100 + parentHex.rowNumber;
+	var seedUsed = userSeed + parentHex.hexID;
 	if(userSeed)
 		init_rng(seedUsed);
 	else
@@ -4078,7 +4078,7 @@ function hexMap(parentObj, parentHex)
 		me.key.addHex(terrainToAdd);
 		for(var i=0;i<neighbours.length;i++)
 		{
-			if(neighbours[i] && neighbours[i].has(terrainObj))
+			if(neighbours[i] && me.edgeHexesBySide[i] && neighbours[i].has(terrainObj))
 				for(var j=0;j<me.edgeHexesBySide[i].length;j++)
 				{
 					me.hexes[me.edgeHexesBySide[i][j]].add(terrainToAdd);
@@ -4272,7 +4272,7 @@ function worldHexMap(parentObj, worldHexToMap)
 		var offsets = [{x:16, y:-28},{x:32,y:0},{x:16,y:28},{x:-16,y:28},{x:-32,y:0},{x:-16,y:-28}];
 		for(var i=0;i<neighbours.length;i++)
 		{
-			if(neighbours[i])
+			if(neighbours[i] && offsets[i])
 			{
 				overallNeighbours.push(new worldHex(me, me.parentObj, null, overallHex.left_offset+offsets[i].x, overallHex.top_offset+offsets[i].y,-3));
 				overallNeighbours[i].terrainTypes = array_fnc.copy.call(neighbours[i].terrainTypes);

--- a/world_mapping.js
+++ b/world_mapping.js
@@ -783,8 +783,18 @@ function worldMap(world, parentObj, containerDiv, blankMap, editMode)
 			iceCapRows = Math.min(iceCapRows + dice(1),me.world.uwp.size*2);
 		if(iceCapRows > -1)
 		{
+                        if(me.getHex(-1,-1).has(islandTerrain))
+                        {
+                                me.getHex(-1,-1).erase(islandTerrain);
+                                me.getHex(-1,-1).add(mountainTerrain);
+                        }
 			me.getHex(-1,-1).add(icecapTerrain);
 			me.getHex(-1,-1).clear = false;
+                        if(me.getHex(-2,-2).has(islandTerrain))
+                        {
+                                me.getHex(-2,-2).erase(islandTerrain);
+                                me.getHex(-2,-2).add(mountainTerrain);
+                        }
 			me.getHex(-2,-2).add(icecapTerrain);
 			me.getHex(-2,-2).clear = false;
 		}
@@ -793,6 +803,11 @@ function worldMap(world, parentObj, containerDiv, blankMap, editMode)
 			{
 				if(me.worldTriangles[i].hexes[j].rowNumber < iceCapRows || ((me.totalRows - me.worldTriangles[i].hexes[j].rowNumber - 1) < iceCapRows))
 				{
+                                        if(me.worldTriangles[i].hexes[j].has(islandTerrain))
+                                        {
+                                                me.worldTriangles[i].hexes[j].erase(islandTerrain);
+                                                me.worldTriangles[i].hexes[j].add(mountainTerrain);
+                                        }
 					me.worldTriangles[i].hexes[j].add(icecapTerrain)
 					me.worldTriangles[i].hexes[j].erase(oceanTerrain);
 					me.worldTriangles[i].hexes[j].clear = false;
@@ -812,6 +827,11 @@ function worldMap(world, parentObj, containerDiv, blankMap, editMode)
 				continue;
 			if(hex.has(oceanTerrain))
 			{
+                                if(hex.has(islandTerrain))
+                                {
+                                        hex.erase(islandTerrain);
+                                        hex.add(mountainTerrain);
+                                }
 				hex.erase(oceanTerrain);
 				hex.add(iceFieldTerrain);
 			}
@@ -837,6 +857,11 @@ function worldMap(world, parentObj, containerDiv, blankMap, editMode)
 					continue;
 				if(hex.has(oceanTerrain))
 				{
+                                        if(hex.has(islandTerrain))
+                                        {
+                                                hex.erase(islandTerrain);
+                                                hex.add(mountainTerrain);
+                                        }
 					hex.erase(oceanTerrain);
 					hex.add(iceFieldTerrain);
 				}
@@ -1228,9 +1253,13 @@ function worldMap(world, parentObj, containerDiv, blankMap, editMode)
 			{
 				if(hex.has(oceanTerrain))
 				{
+					if(hex.has(islandTerrain))
+					{
+						hex.erase(islandTerrain);
+						hex.add(mountainTerrain);
+					}
 					hex.erase(oceanTerrain);
 					hex.add(iceFieldTerrain);
-					hex.erase(islandTerrain);
 				}
 				else
 				{
@@ -1241,13 +1270,13 @@ function worldMap(world, parentObj, containerDiv, blankMap, editMode)
 			{
 				if(hex.has(oceanTerrain))
 				{
-					hex.erase(oceanTerrain);
-					hex.add(desertTerrain);
 					if(hex.has(islandTerrain))
 					{
 						hex.erase(islandTerrain);
 						hex.add(mountainTerrain);
 					}
+					hex.erase(oceanTerrain);
+					hex.add(desertTerrain);
 				}
 				else
 				{

--- a/world_mapping.js
+++ b/world_mapping.js
@@ -1735,7 +1735,8 @@ var cratersTerrain = {name:"Craters", code:74, draw:function(aWorldHex)
 															var strokeColour = uPObj.prefs.black_and_white_map ? "black" : "rgb(64,64,64)";
 															var craterFill = uPObj.prefs.black_and_white_map ? "white" : "rgb(204,204,204)";
 															var fillColour = uPObj.prefs.black_and_white_map ? "white" : "rgb(194,194,163";
-															addCircle(l+16, t+17, 9, 1, strokeColour, craterFill,aWorldHex.parentObj);
+                                                                                                                        var fillOpacity = 0.5;  // needed so underlying symbols remain visible
+															addCircle(l+16, t+17, 9, 1, strokeColour, craterFill,aWorldHex.parentObj, fillOpacity);
 															aWorldHex.hexElem.style.fill = fillColour;
 
 														}, toString:function(){ return this.name}, preferLand:true, type:0};
@@ -2217,7 +2218,8 @@ var lakeTerrain = {name:"Lake", code:35, draw:function(aWorldHex)
 															var l = aWorldHex.left_offset;
 															var t = aWorldHex.top_offset;
 															var lakeFill = uPObj.prefs.black_and_white_map ? "rgb(127,127,127)" : "blue";
-															addCircle(l+16, t+17, 8, 1, "black", lakeFill,aWorldHex.parentObj);
+                                                                                                                        var fillOpacity = 0.5;  // needed so underlying symbols remain visible
+															addCircle(l+16, t+17, 8, 1, "black", lakeFill,aWorldHex.parentObj, fillOpacity);
 														}, toString:function() {return this.name} , preferLand:true, type:0};
 var lakeTerrain2 = {name: "Lake", code: 37, draw:function(aWorldHex)
 														{
@@ -4533,13 +4535,15 @@ function addLine(x1, y1, x2, y2, strokeWidth, stroke, parentObj, dashed)
 
 }
 
-function addCircle(cx, cy, r, strokeWidth, stroke, fill, parentObj)
+function addCircle(cx, cy, r, strokeWidth, stroke, fill, parentObj, opacity)
 {
 	var circle = document.createElementNS(svgNS,"circle");
 	circle.setAttributeNS(null,"cx",cx);
 	circle.setAttributeNS(null,"cy",cy);
 	circle.setAttributeNS(null,"r",r);
-	circle.setAttributeNS(null,"style","stroke=width:" + strokeWidth + ";stroke:" + stroke + ";fill:" + fill);
+        if(!opacity)
+                opacity = 1.0;
+	circle.setAttributeNS(null,"style","stroke=width:" + strokeWidth + ";stroke:" + stroke + ";fill:" + fill + ";fill-opacity:"+opacity);
 	parentObj.appendChild(circle);
 }
 

--- a/world_mapping.js
+++ b/world_mapping.js
@@ -1650,7 +1650,7 @@ defines the actual drawing of terrain, its code for saving, its name, and variou
 Type is an integer with the following meanings:
 0 - base terrain: a hex must have exactly one base terrain assigned
 1 - symbol: a hex can have any number of terrain classed as a symbol
-2 - overlay: a hex may have 0 or 1 overlay terrain (generally the half-hexes needed for Twilight Zone worlds)
+2 - overlay: a hex may have 0, 1 or 2 overlay terrain (generally the half-hexes needed for Twilight Zone worlds)
 3 - key only: may not be placed on the map (e.g. scale)
 
 */
@@ -1748,14 +1748,16 @@ var desertTerrain = {name:"Desert", code:22, draw: function(aWorldHex)
 															var strokeColour = uPObj.prefs.black_and_white_map ? "black" : "rgb(230,172,0)";
 															addLine(l+3,t+17,l+30,t+17,"3px",strokeColour,aWorldHex.parentObj);
 															aWorldHex.hexElem.style.fill = fillColour;
-														}, toString:function(){ return this.name}, preferLand:false, type:0};														
+														}, toString:function(){ return this.name}, preferLand:false, type:0};
 var desertTerrainWest = {name:"Desert West Half Only", code:118, draw: function(aWorldHex)
 														{
 															var l = aWorldHex.left_offset;
 															var t = aWorldHex.top_offset;
 															var fillColour = uPObj.prefs.black_and_white_map ? uPObj.prefs.desert_terrain_bw_bg : uPObj.prefs.desert_terrain_bg;
 															var strokeColour = uPObj.prefs.black_and_white_map ? "black" : "rgb(230,172,0)";
-															addPolygon((l+16) + "," + t + " " + (l+16) + "," + (t+35) + " " + l + "," + (t+28) + " " + l + "," + (t+7), 1, "black", fillColour,aWorldHex.parentObj);
+															var overlayElem = addPolygon((l+16) + "," + t + " " + (l+16) + "," + (t+35) + " " + l + "," + (t+28) + " " + l + "," + (t+7), 1, "black", fillColour,aWorldHex.parentObj);
+                                                                                                                        if(aWorldHex && aWorldHex.parentTriangle)
+                                                                                                                                overlayElem.onclick = function() { aWorldHex.editTerrain(); };
 															addLine(l+3,t+17,l+16,t+17,"3px",strokeColour,aWorldHex.parentObj);
 														}, toString:function(){ return this.name}, preferLand:false, type:2};
 var desertTerrainEast = {name:"Desert East Half Only", code:119, draw: function(aWorldHex)
@@ -1764,7 +1766,9 @@ var desertTerrainEast = {name:"Desert East Half Only", code:119, draw: function(
 															var t = aWorldHex.top_offset;
 															var fillColour = uPObj.prefs.black_and_white_map ? uPObj.prefs.desert_terrain_bw_bg : uPObj.prefs.desert_terrain_bg;
 															var strokeColour = uPObj.prefs.black_and_white_map ? "black" : "rgb(230,172,0)";
-															addPolygon((l+16) + "," + t + " " + (l+32) + "," + (t+7) + " " + (l+32) + "," + (t+28) + " " + (l+16) + "," + (t+35), 1, "black", fillColour,aWorldHex.parentObj);
+															var overlayElem = addPolygon((l+16) + "," + t + " " + (l+32) + "," + (t+7) + " " + (l+32) + "," + (t+28) + " " + (l+16) + "," + (t+35), 1, "black", fillColour,aWorldHex.parentObj);
+                                                                                                                        if(aWorldHex && aWorldHex.parentTriangle)
+                                                                                                                                overlayElem.onclick = function() { aWorldHex.editTerrain(); };
 															addLine(l+16,t+17,l+30,t+17,"3px",strokeColour,aWorldHex.parentObj);
 														}, toString:function(){ return this.name}, preferLand:false, type:2};
 var oceanTerrain = {name:"Ocean", code:31, draw: function(aWorldHex)
@@ -1869,7 +1873,9 @@ var iceFieldTerrainWest = {name:"Ice Field West Half Only", code:108, draw:funct
 															s += "M " + (l+13) + " " + (t+10) + " L " + (l+14) + " " + (t+6) + " L " + (l+16) + " " + (t+6) + " ";
 															var s1 = "M " + (l+5) + " " + (t+15) + " Q " + (l+11) + " " + (t+11) + " " + (l+16) + " " + (t+15);
 															var fillColour = uPObj.prefs.black_and_white_map ? "white" : "rgb(230,236,255)";
-															addPolygon((l+16) + "," + t + " " + (l+16) + "," + (t+35) + " " + l + "," + (t+28) + " " + l + "," + (t+7), 1, "black", fillColour,aWorldHex.parentObj);
+															var overlayElem = addPolygon((l+16) + "," + t + " " + (l+16) + "," + (t+35) + " " + l + "," + (t+28) + " " + l + "," + (t+7), 1, "black", fillColour,aWorldHex.parentObj);
+                                                                                                                        if(aWorldHex && aWorldHex.parentTriangle)
+                                                                                                                                overlayElem.onclick = function() { aWorldHex.editTerrain(); };
 															addPath(s, 2, "black", "none",aWorldHex.parentObj);
 															addPath(s1,2,"black","none",aWorldHex.parentObj);
 														}, toString:function(){ return this.name}, preferLand:false, type:2};
@@ -1882,7 +1888,9 @@ var iceFieldTerrainEast = {name:"Ice Field East Half Only", code:109, draw:funct
 															s += "M " + (l+21) + " " + (t+10) + " L " + (l+22) + " " + (t+6) + " L " + (l+26) + " " + (t+6) + " L " + (l+27) + " " + (t+10) + " ";
 															var s1 = "M " + (l+16) + " " + (t+15) + " Q " + (l+21) + " " + (t+19) + " " + (l+27) + " " + (t+15);
 															var fillColour = uPObj.prefs.black_and_white_map ? "white" : "rgb(230,236,255)";
-															addPolygon((l+16) + "," + t + " " + (l+32) + "," + (t+7) + " " + (l+32) + "," + (t+28) + " " + (l+16) + "," + (t+35), 1, "black", fillColour, aWorldHex.parentObj);
+															var overlayElem = addPolygon((l+16) + "," + t + " " + (l+32) + "," + (t+7) + " " + (l+32) + "," + (t+28) + " " + (l+16) + "," + (t+35), 1, "black", fillColour, aWorldHex.parentObj);
+                                                                                                                        if(aWorldHex && aWorldHex.parentTriangle)
+                                                                                                                                overlayElem.onclick = function() { aWorldHex.editTerrain(); };
 															addPath(s, 2, "black", "none", aWorldHex.parentObj);
 															addPath(s1, 2,"black", "none", aWorldHex.parentObj);
 														}, toString:function(){ return this.name}, preferLand:false, type:2};
@@ -1901,7 +1909,9 @@ var frozenLandTerrainWest = {name:"Frozen Land West Half Only", code:106, draw:f
 															var l = aWorldHex.left_offset;
 															var t = aWorldHex.top_offset;
 															var fillColour = uPObj.prefs.black_and_white_map ? "white" : "rgb(219,223,185)";
-															addPolygon((l+16) + "," + t + " " + (l+16) + "," + (t+35) + " " + l + "," + (t+28) + " " + l + "," + (t+7), 1, "black", fillColour,aWorldHex.parentObj);
+															var overlayElem = addPolygon((l+16) + "," + t + " " + (l+16) + "," + (t+35) + " " + l + "," + (t+28) + " " + l + "," + (t+7), 1, "black", fillColour,aWorldHex.parentObj);
+                                                                                                                        if(aWorldHex && aWorldHex.parentTriangle)
+                                                                                                                                overlayElem.onclick = function() { aWorldHex.editTerrain(); };
 															addLine(l+5,t+7,l+16,t+7,"2px","rgb(0,0,0)",aWorldHex.parentObj);
 															addPath("M " + (l+5) + " " + (t+12) + " Q " + (l+11) + " " + (t+9) + " " + (l+16) + " " + (t+12), 2, "black", "none",aWorldHex.parentObj);
 														}, toString:function(){ return this.name}, preferLand:false, type:2};
@@ -1910,7 +1920,9 @@ var frozenLandTerrainEast = {name:"Frozen Land East Half Only", code:107, draw:f
 															var l = aWorldHex.left_offset;
 															var t = aWorldHex.top_offset;
 															var fillColour = uPObj.prefs.black_and_white_map ? "white" : "rgb(219,223,185)";
-															addPolygon((l+16) + "," + t + " " + (l+32) + "," + (t+7) + " " + (l+32) + "," + (t+28) + " " + (l+16) + "," + (t+35), 1, "black", fillColour,aWorldHex.parentObj);
+															var overlayElem = addPolygon((l+16) + "," + t + " " + (l+32) + "," + (t+7) + " " + (l+32) + "," + (t+28) + " " + (l+16) + "," + (t+35), 1, "black", fillColour,aWorldHex.parentObj);
+                                                                                                                        if(aWorldHex && aWorldHex.parentTriangle)
+                                                                                                                                overlayElem.onclick = function() { aWorldHex.editTerrain(); };
 															addLine(l+16,t+7,l+27,t+7,"2px","black",aWorldHex.parentObj);
 															addPath("M " + (l+16) + " " + (t+12) + " Q " + (l+21) + " " + (t+15) + " " + (l+27) + " " + (t+12), 2, "black", "none",aWorldHex.parentObj);
 														}, toString:function(){ return this.name}, preferLand:false, type:2};
@@ -2011,7 +2023,9 @@ var bakedLandsWestHalfTerrain = {name:"Baked Lands West Half Only", code:104, dr
 															var t = aWorldHex.top_offset;
 															var strokeColour = uPObj.prefs.black_and_white_map ? "black" : "rgb(204,0,0)";
 															var fillColour = uPObj.prefs.black_and_white_map ? "white" : "rgb(255,119,51)";
-															addPolygon((l+16) + "," + t + " " + (l+16) + "," + (t+35) + " " + l + "," + (t+28) + " " + l + "," + (t+7), 1, "black", fillColour,aWorldHex.parentObj);
+															var overlayElem = addPolygon((l+16) + "," + t + " " + (l+16) + "," + (t+35) + " " + l + "," + (t+28) + " " + l + "," + (t+7), 1, "black", fillColour,aWorldHex.parentObj);
+                                                                                                                        if(aWorldHex && aWorldHex.parentTriangle)
+                                                                                                                                overlayElem.onclick = function() { aWorldHex.editTerrain(); };
 															for(var i=0;i<4;i++)
 																addRectangle(l+3+i*4,t+7,2,2,strokeColour,"1px",strokeColour,aWorldHex.parentObj);
 															addLine(l+3,t+11,l+16,t+11,"2px",strokeColour,aWorldHex.parentObj);
@@ -2022,7 +2036,9 @@ var bakedLandsEastHalfTerrain = {name:"Baked Lands East Half Only", code:105, dr
 															var t = aWorldHex.top_offset;
 															var strokeColour = uPObj.prefs.black_and_white_map ? "black" : "rgb(204,0,0)";
 															var fillColour = uPObj.prefs.black_and_white_map ? "white" : "rgb(255,119,51)";
-															addPolygon((l+16) + "," + t + " " + (l+32) + "," + (t+7) + " " + (l+32) + "," + (t+28) + " " + (l+16) + "," + (t+35), 1, "black", fillColour,aWorldHex.parentObj);
+															var overlayElem = addPolygon((l+16) + "," + t + " " + (l+32) + "," + (t+7) + " " + (l+32) + "," + (t+28) + " " + (l+16) + "," + (t+35), 1, "black", fillColour,aWorldHex.parentObj);
+                                                                                                                        if(aWorldHex && aWorldHex.parentTriangle)
+                                                                                                                                overlayElem.onclick = function() { aWorldHex.editTerrain(); };
 															for(var i=4;i<7;i++)
 																addRectangle(l+3+i*4,t+7,2,2,strokeColour,"1px",strokeColour,aWorldHex.parentObj);
 															addLine(l+16,t+11,l+29,t+11,"2px",strokeColour,aWorldHex.parentObj);
@@ -2682,9 +2698,12 @@ function worldHex(worldMapObj, parentObj, parentTriangle, left_offset, top_offse
 					me.add(terrainToAdd);					
 				break;
 			case 2:
-				var existingOverlay = me.terrainTypes.find(function(v) { return v.type == 1; });
+				var addingWest = (terrainToAdd.name.indexOf("West") >= 0)
+				var existingOverlay = me.terrainTypes.find(function(v) { return v.type == 2 && v.name.indexOf(addingWest?"West":"East") >= 0; });
 				if(existingOverlay === undefined)
 					me.add(terrainToAdd);
+				else if(existingOverlay === terrainToAdd)
+					me.erase(existingOverlay);
 				else
 					me.transform(existingOverlay, terrainToAdd);				
 		}

--- a/world_mapping.js
+++ b/world_mapping.js
@@ -102,18 +102,16 @@ function worldMap(world, parentObj, containerDiv, blankMap, editMode)
 		if(!me.blank)
 		{
 			mountains();
+			chasms();
+			precipices();
+			exotic();
+			resourceHexes();
 			oceans();
 			continents(); // not actual terrain placement, but defines a continent as all non-ocean hexes in a world triangle
 			craters();
 			seas();
-			icecaps();
-			frozenPlanet();
-			tundra();
-			twilightZone();
 			cities();
 			rural();
-			chasms();
-			precipices();
 			ruins();
 			cropLand();
 			lowPopulTown();
@@ -121,11 +119,15 @@ function worldMap(world, parentObj, containerDiv, blankMap, editMode)
 			starport();
 			penal();
 			waste();
-			exotic();
+			icecaps();
+			frozenPlanet();
+			hellishPlanet();
+			moltenPlanet();
+			tundra();
 			desert();
+			twilightZone();
 			if(uPObj.prefs.place_noble_estate)
 				nobleLand();
-			resourceHexes();
 			clearTerrainAllocate();
 		}
 	}

--- a/world_mapping.js
+++ b/world_mapping.js
@@ -3177,7 +3177,9 @@ function generateHexMap(parentHex, mapType, mapClass)
 
 
 	var userSeed = parseInt(document.getElementById("seed").value);
-	var seedUsed = userSeed + parentHex.hexID;
+        var seedUsed = userSeed + parentHex.columnNumber * 100 + parentHex.rowNumber;
+        if(parentHex.hexID < 0)
+            seedUsed = userSeed + parentHex.hexID;
 	if(userSeed)
 		init_rng(seedUsed);
 	else

--- a/world_mapping.js
+++ b/world_mapping.js
@@ -39,8 +39,8 @@ function worldMap(world, parentObj, containerDiv, blankMap, editMode)
 		me.map_top_offset = 200;
 		me.mapHeight = me.map_top_offset+(3*me.world.uwp.size+1)*28+MAP_KEY_HEIGHT;
 	}
-	me.parentObj.setAttributeNS(null,"height","");
-	me.parentObj.setAttributeNS(null,"width","100%");	
+	me.parentObj.setAttributeNS(null,"height","100%");
+	me.parentObj.setAttributeNS(null,"width","100%");
 	me.parentObj.setAttributeNS(null,"viewBox","0 0 " + me.mapWidth + " " + me.mapHeight);
 	me.topCoverTrianglePoints = [];
 	me.bottomCoverTrianglePoints = [];

--- a/world_mapping.js
+++ b/world_mapping.js
@@ -121,8 +121,8 @@ function worldMap(world, parentObj, containerDiv, blankMap, editMode)
 			waste();
 			icecaps();
 			frozenPlanet();
-			hellishPlanet();
-			moltenPlanet();
+			//hellishPlanet();
+			//moltenPlanet();
 			tundra();
 			desert();
 			twilightZone();

--- a/world_mapping.js
+++ b/world_mapping.js
@@ -3155,14 +3155,14 @@ function generateHexMap(parentHex, mapType, mapClass)
 
 
 	var userSeed = parseInt(document.getElementById("seed").value);
-	var seedUsed = userSeed;
+	var seedUsed = userSeed + parentHex.columnNumber * 100 + parentHex.rowNumber;
 	if(userSeed)
 		init_rng(seedUsed);
 	else
 	{
 		seedUsed = Date.now() >>> 0;
 	}
-	document.getElementById("seed").value = seedUsed;
+//	document.getElementById("seed").value = seedUsed;
 
 	var map = new mapClass(hexMapSVG, parentHex);
 	map.generate();

--- a/world_mapping.js
+++ b/world_mapping.js
@@ -616,6 +616,8 @@ function worldMap(world, parentObj, containerDiv, blankMap, editMode)
 
 	function addOcean(selectedHex)
 	{
+		if(me.world.tcs.has("Va"))
+			return;
 		selectedHex.terrainTypes.push(oceanTerrain);
 		selectedHex.clear = false;
 		if(selectedHex.has(mountainTerrain))

--- a/world_mapping.js
+++ b/world_mapping.js
@@ -2645,12 +2645,12 @@ function worldHex(worldMapObj, parentObj, parentTriangle, left_offset, top_offse
 
 	me.calcRow = function()
 	{
-		return me.top_offset < 0 ? me.top_offset : (me.top_offset - me.map.map_top_offset) / 28;
+		return me.top_offset < 0 ? me.top_offset : Math.round((me.top_offset - me.map.map_top_offset) / 28);
 	}
 
 	me.calcCol = function()
 	{
-		return me.left_offset < 0 ? me.left_offset : (me.left_offset - me.map.map_left_offset) / 16;
+		return me.left_offset < 0 ? me.left_offset : Math.round((me.left_offset - me.map.map_left_offset) / 16);
 	}
 
 	me.render = function(editFlag)
@@ -2939,12 +2939,12 @@ function terrainHex(worldHexMapObject, parentObj, left_offset, top_offset)
 
 	me.calcCol = function()
 	{
-		return (me.left_offset - HEX_MAP_LEFT_OFFSET) / 27;
+		return Math.round((me.left_offset - HEX_MAP_LEFT_OFFSET) / 27);
 	}
 
 	me.calcRow = function()
 	{
-		return (me.top_offset - HEX_MAP_TOP_OFFSET) / 16;
+		return Math.round((me.top_offset - HEX_MAP_TOP_OFFSET) / 16);
 	}
 
 	me.render = function()
@@ -2995,12 +2995,12 @@ function localHex(terrainHexMapObject, parentObj, left_offset, top_offset)
 
 	me.calcCol = function()
 	{
-		return (me.left_offset - HEX_MAP_LEFT_OFFSET) / 16;
+		return Math.round((me.left_offset - HEX_MAP_LEFT_OFFSET) / 16);
 	}
 
 	me.calcRow = function()
 	{
-		return (me.top_offset - HEX_MAP_TOP_OFFSET) / 28;
+		return Math.round((me.top_offset - HEX_MAP_TOP_OFFSET) / 28);
 	}
 
 	me.render = function()
@@ -3059,12 +3059,12 @@ function singleHex(terrainHexMapObject, parentObj, left_offset, top_offset)
 
 	me.calcCol = function()
 	{
-		return (me.left_offset - HEX_MAP_LEFT_OFFSET) / 27;
+		return Math.round((me.left_offset - HEX_MAP_LEFT_OFFSET) / 27);
 	}
 
 	me.calcRow = function()
 	{
-		return (me.top_offset - HEX_MAP_TOP_OFFSET) / 16;
+		return Math.round((me.top_offset - HEX_MAP_TOP_OFFSET) / 16);
 	}
 
 	me.render = function()

--- a/world_mapping.js
+++ b/world_mapping.js
@@ -101,7 +101,6 @@ function worldMap(world, parentObj, containerDiv, blankMap, editMode)
 			return;
 		if(!me.blank)
 		{
-			desert();
 			mountains();
 			oceans();
 			continents(); // not actual terrain placement, but defines a continent as all non-ocean hexes in a world triangle
@@ -123,6 +122,7 @@ function worldMap(world, parentObj, containerDiv, blankMap, editMode)
 			penal();
 			waste();
 			exotic();
+			desert();
 			if(uPObj.prefs.place_noble_estate)
 				nobleLand();
 			resourceHexes();
@@ -738,6 +738,7 @@ function worldMap(world, parentObj, containerDiv, blankMap, editMode)
 		if(!me.world.tcs.has("De"))
 			return;
 		for(var i=0;i<me.hexes.length;i++)
+                    if(!me.hexes[i].has(oceanTerrain) && !me.hexes[i].has(icecapTerrain))
 			me.hexes[i].add(desertTerrain);
 	}
 

--- a/world_mapping.js
+++ b/world_mapping.js
@@ -849,6 +849,28 @@ function worldMap(world, parentObj, containerDiv, blankMap, editMode)
 		if(!me.world.tcs.has("Tu"))
 			return;
 		var numTundraRows = dice(1);
+                var poles = [me.getHex(-1,-1), me.getHex(-2,-2)]
+                for (var i in poles)
+                {
+                    var hex = poles[i];
+                    if(!hex.has(icecapTerrain))
+                    {
+				if(hex.has(oceanTerrain))
+				{
+                                        if(hex.has(islandTerrain))
+                                        {
+                                                hex.erase(islandTerrain);
+                                                hex.add(mountainTerrain);
+                                        }
+					hex.erase(oceanTerrain);
+					hex.add(iceFieldTerrain);
+				}
+				else
+				{
+					hex.add(frozenLandTerrain);
+				}
+                    }
+                }
 		for(var i=0;i<me.worldTriangles.length;i++)
 			for(var j=0;j<me.worldTriangles[i].hexes.length;j++)
 			{


### PR DESCRIPTION
1, "tc" parameters supplied now actually affect world generation, e.g. supplying the code "tc=Tz" in the URL header now actually produces a Twilight Zone map. Similarly for using Generate > New star system.
2. "tc=Pl" - new parameter to mark worlds that are not satellites. Will be used internally to improve planet and satellite selection.
3. If "Pl", "Sa" or "Lk" are included in tc parameters, don't randomly determine world type.
4. Vacuum worlds no longer attempt to add oceans (rules say water will be locked in ice caps and world should attract "Ic" code).
5. Desert terrain will no longer be added to ocean or icecap hexes.
6. Islands are now consistently converted back to mountains for ice cap, ice field, and desert terrain. Mountain is added back to desert terrain so the hex now has both.
7. Half-hex over terrain can now be subtracted or added in the map editor, and be toggled on or off.
8. Some minor corrections to prevent errors in the console output.
9. Terrain render order has been changed so that landforms don't change when switching climate codes.  This gives the ability to see the same planet in baked, temperate or frozen conditions.
10.  Craters and lakes are now translucent so as not to hide underlying symbols.
11. World Hex maps now use a repeatable hex-specific seed so that identical terrain types can have different features, but a given world hex still has the same features each time it is generated
12. If "tc=Pl" code is given, don't run a check for being locked to the star to prevent Twilight Zone maps being added unexpectedly.
13. Tundra hexes are added to poles if there is no ice cap present.
