### PR TITLE
1.1.1 - Ruthless Veil bug fixes

### DIFF
--- a/government_details.js
+++ b/government_details.js
@@ -349,6 +349,7 @@ function balkanised(world)
 	me.states = [];
 	me.history = "";
 	me.numStates = 0;
+	me.govOverflowMsg = "";
 
 	me.toString = function()
 	{
@@ -356,7 +357,8 @@ function balkanised(world)
 		var s = me.history.desc;
 		s += " There are " + me.numStates + " states on this world.";
 		s += " The conflict level is " + me.conflict.title + ". " + me.conflict.desc;
-		s += me.allNations();		
+		s += me.allNations();
+		s += me.govOverflowMsg;
 		return s;
 	}
 	
@@ -437,6 +439,11 @@ function balkanised(world)
 		}
 		me.states.push(new nationState(me, newGov));
 		i++;
+		if(i > uPObj.prefs.balkanised_gov_max)
+		{
+			me.govOverflowMsg = " There are more governments, but only the first " + uPObj.prefs.balkanised_gov_max + " have been generated. ";
+			break;
+		}
 	}		
 }
 

--- a/government_details.js
+++ b/government_details.js
@@ -402,11 +402,11 @@ function balkanised(world)
 	
 	me.allNations = function()
 	{
-		var s = "These are the characteristics each state: ";
+		var s = "\n\nThese are the characteristics for each state:";
 
 		for(var i=0;i<me.states.length;i++)
 		{
-			s += "Nation " + (i+1) + ": ";
+			s += "\n\tNation " + (i+1) + ": ";
 			s += me.states[i].toString() + " ";
 
 		}
@@ -423,10 +423,15 @@ function balkanised(world)
 	if(me.world.uwp.TL >=7 && me.conflict.title == "Very High")
 		me.conflict.desc += (dice(1) == 6 ? " At least one nation has used nuclear weapons on another." : "");
 	if(dice(2) > me.conflict.rollResult)
-		me.conflict.desc += " There is a supra-national body similar to the United Nations.";
+		me.conflict.desc += "\n\n(There is a supra-national body similar to the United Nations.)";
 	var i = 0;
 	while(i < me.numStates)
 	{
+		if(i >= uPObj.prefs.balkanised_gov_max)
+		{
+			me.govOverflowMsg = "\n\n(There are more governments, but only the first " + uPObj.prefs.balkanised_gov_max + " have been generated.)";
+			break;
+		}
 		var newGov = flux() + me.world.uwp.popul;
 		if(me.numStates > 1 && me.numStates < 5)
 			newGov++;
@@ -436,15 +441,16 @@ function balkanised(world)
 		if(newGov == 7)
 		{
 			me.numStates += me.history.numStates();
+			continue;
 		}
 		me.states.push(new nationState(me, newGov));
 		i++;
-		if(i > uPObj.prefs.balkanised_gov_max)
-		{
-			me.govOverflowMsg = " There are more governments, but only the first " + uPObj.prefs.balkanised_gov_max + " have been generated. ";
-			break;
-		}
-	}		
+	}
+	me.states[0].port = me.world.uwp.port;
+	me.states.sort(function(state1, state2)
+						{
+							return state1.port.localeCompare(state2.port);
+						});
 }
 
 function nationState(govDetailObj, gov)
@@ -454,7 +460,7 @@ function nationState(govDetailObj, gov)
 	me.balk = govDetailObj;
 	me.gov = gov;
 	me.law = Math.max(0,me.gov + flux());
-	me.port = subPortTbl[me.world.uwp.port][Math.min(6,Math.max(1,dice(1)+me.balk.history.subPortDM))];
+	me.port = subPortTbl[me.world.uwp.port][Math.min(6,Math.max(1,dice(1)+me.balk.history.subPortDM-1))];
 	me.TL = Math.max(0,me.world.uwp.TL + TLmodTbl[me.world.uwp.port][me.port]);
 	me.anglic_status = new dice_table(anglic_table, null, me.world).roll();
 	if(me.anglic_status == "The vast majority of citizens speak Anglic as their first language")

--- a/index.html
+++ b/index.html
@@ -947,7 +947,7 @@
 			<input type="checkbox" id="tz_no_sat" />Tidally locked worlds may not have satellites<br />
 			<input type="checkbox" id="barren_sys" />If main world population is zero, all system worlds are Barren<br />
 			<input type="checkbox" id="download_world_detail" />When downloading the system to save a local copy, include all details for all worlds<br />
-			<input type="number" min="0" style="width:30pt;" id="balkanised_gov_max" />Maximum number of governments generated in a Balkanised world<br />
+			<input type="number" min="2" style="width:30pt;" id="balkanised_gov_max" />Maximum number of governments generated in a Balkanised world<br />
 			</div>
 			<div class="contained" style="font-size:0.8em;">
 			<h2 style="margin-top: 0em;">Map Generation Preferences</h2>

--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
 </head>
 <body onload="initLoad();" >
 	<div class="container">
-		<h1 class="title"><img src="150px-Imperial_Sunburst-Sun-IISS-Traveller.gif" height="30" width="30">Traveller Worlds <span style="font-size:0.5em">v1.1.0</span></h1>
+		<h1 class="title"><img src="150px-Imperial_Sunburst-Sun-IISS-Traveller.gif" height="30" width="30">Traveller Worlds <span style="font-size:0.5em">v1.1.1</span></h1>
 		<h1 class="titleStrap">TRAVELLER<sup style="margin-left:0.25em;color:white;font-weight:bold;font-family:Arial">5</sup></h1>
 		<h1 class="subtitle">Science Fiction Adventure</h1>
 		<h1 class="subtitle">in the Far Future</h1>
@@ -947,6 +947,7 @@
 			<input type="checkbox" id="tz_no_sat" />Tidally locked worlds may not have satellites<br />
 			<input type="checkbox" id="barren_sys" />If main world population is zero, all system worlds are Barren<br />
 			<input type="checkbox" id="download_world_detail" />When downloading the system to save a local copy, include all details for all worlds<br />
+			<input type="number" min="0" style="width:30pt;" id="balkanised_gov_max" />Maximum number of governments generated in a Balkanised world<br />
 			</div>
 			<div class="contained" style="font-size:0.8em;">
 			<h2 style="margin-top: 0em;">Map Generation Preferences</h2>

--- a/planet_building_world_class.js
+++ b/planet_building_world_class.js
@@ -25,6 +25,7 @@ var defaultPrefs = {
 	main_world_not_sat:false,
 	tz_no_sat:false,
 	barren_sys:false,
+	balkanised_gov_max:60,
 	download_world_detail:true,
 	shoreline_extend_chance:40,
 	creep_into_tz_chance:30,
@@ -2767,6 +2768,7 @@ function eX(world)
 			me.generate();
 			return;
 		}
+		s = s.toUpperCase();
 		me.resources = readPseudoHex(s.substr(1,1));
 		me.labour = readPseudoHex(s.substr(2,1));
 		me.infrastructure = readPseudoHex(s.substr(3,1));
@@ -2820,6 +2822,7 @@ function cX(world)
 			me.generate();
 			return;
 		}
+		s = s.toUpperCase();
 		me.homogeneity = readPseudoHex(s.substr(1,1));
 		me.acceptance = readPseudoHex(s.substr(2,1));
 		me.strangeness = readPseudoHex(s.substr(3,1));
@@ -3428,12 +3431,14 @@ function starSystem(world)
 	{
 		if(typeof(s) != "string" || s.trim()=="")
 			return;
+		s = s.toUpperCase();
 		s = s.replace(/[OBAFGKM]\d\s(D)/g,function(x) { return x.replace(/\sD/g, " V"); });
 		s = s.replace(/F[0-4]\sVI/g, "F5 VI"); // F0 VI, F1 VI, F2 VI, F3 VI, F4 VI all converted to F5 VI
 		s = s.replace(/K[0-5]\sIV/g, "K6 IV"); // K0 through K5 IV converted to K6 IV
 		s = s.replace(/M[0-9]\sIV/g, function(x) { return x.replace(/\sIV/g, " V"); }); // convert M0 - M9 IV to V
 		s = s.replace(/O[0-1]/g, "O2"); // no O1 or O0 - both become O2
 		s = s.replace(/O[2-9]\sVI/g, function(x) { return x.replace(/\sVI/g, " V"); }); // convert any O-type subdwarfs to dwarfs
+		s = s.replace(/(A|B)[0-9]\sVI/g, function(x) { return x.replace(/\sVI/g, " V"); }); // convert any B-type subdrawfs to dwarfs
 		me.stars = [];
 		me.companions = [];
 		var starStrings = s.match(/([OBAFGKMLTY]\d\s(Ia|Ib|IV|V?I{0,3}|D))|(BD)(\s?})|(\s{0,1})(D)|(\s{0,1})(N)|(\s{0,1})(B)/g);

--- a/planet_building_world_class.js
+++ b/planet_building_world_class.js
@@ -2429,6 +2429,7 @@ function uwp(worldObject)
 
 	me.readUWP = function(uwpString)
 	{
+		uwpString = uwpString.toUpperCase();
 		me.port = uwpString.substr(0,1);
 		me.size = readPseudoHex(uwpString.substr(1,1));
 		me.atmos = readPseudoHex(uwpString.substr(2,1));


### PR DESCRIPTION
(1) When generating nation states for balkanised worlds (Government Type 7), the number of generated states is limited to 60 arbitrarily to prevent memory overflow and infinite loops. This number can be modified in User Preferences.
(2) When reading stellar data, we now convert all Spectral Class O, A, and B as well as F0 - F4 subdwarfs (size VI) to dwarfs (size V) as subdwarfs in those spectral classes do not exist.
(3) Economic Extension, Cultural Extension and UWP input strings converted to upper case before processing from user provided data as lower case letters were leading to fatal errors